### PR TITLE
change visibility of buildMessage(String) to support builds against liquibase >= 3.2.0

### DIFF
--- a/src/main/java/liquibase/ext/logging/slf4j/Slf4jLogger.java
+++ b/src/main/java/liquibase/ext/logging/slf4j/Slf4jLogger.java
@@ -183,7 +183,7 @@ public class Slf4jLogger extends AbstractLogger {
      * @param message The basic log message before optional data.
      * @return the complete log message to print to the logger.
      */
-    private String buildMessage(String message) {
+    protected String buildMessage(String message) {
         StringBuilder msg = new StringBuilder();
         if(changeLogName != null) {
             msg.append(changeLogName).append(": ");


### PR DESCRIPTION
I know that you've contributed the patch introducing `buildMessage(String)` to liquibase, so you are likely aware of this.

alternatively, you could remove the method altogether along with `changeLogName` and `changeSetName` (and their setters) but that would require 3.2 as minimum dependency to work