### PR TITLE
Ensure JUL OFF level is respected in liquibase logger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - '*'
   pull_request:
     branches:
-      - $default-branch
+      - '*'
 
 jobs:
   build:

--- a/src/main/java/com/mattbertolini/liquibase/logging/slf4j/Slf4jLogger.java
+++ b/src/main/java/com/mattbertolini/liquibase/logging/slf4j/Slf4jLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Matt Bertolini
+ * Copyright (c) 2012-2024 Matt Bertolini
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
@@ -60,12 +60,13 @@ import java.util.logging.Level;
  * @author Matt Bertolini
  * @see liquibase.logging.Logger
  */
-public class Slf4jLogger extends AbstractLogger {
+public class Slf4jLogger extends AbstractLogger implements liquibase.logging.Logger {
 
     private static final int TRACE_THRESHOLD = Level.FINEST.intValue();
     private static final int DEBUG_THRESHOLD = Level.FINE.intValue();
     private static final int INFO_THRESHOLD = Level.INFO.intValue();
     private static final int WARN_THRESHOLD = Level.WARNING.intValue();
+    private static final int ERROR_THRESHOLD = Level.SEVERE.intValue();
 
     private final Logger logger;
 
@@ -85,7 +86,7 @@ public class Slf4jLogger extends AbstractLogger {
             logger.info(message, e);
         } else if (levelValue <= WARN_THRESHOLD) {
             logger.warn(message, e);
-        } else {
+        } else if (levelValue <= ERROR_THRESHOLD) {
             logger.error(message, e);
         }
     }

--- a/src/test/java/com/mattbertolini/liquibase/logging/slf4j/Slf4jLoggerTest.java
+++ b/src/test/java/com/mattbertolini/liquibase/logging/slf4j/Slf4jLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 Matt Bertolini
+ * Copyright (c) 2012-2024 Matt Bertolini
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
  * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -86,6 +87,12 @@ class Slf4jLoggerTest {
         String message = "finest test";
         logger.log(Level.FINEST, message, null);
         verify(delegate).trace(message, (Throwable) null);
+    }
+
+    @Test
+    void doesNotLogWithOffLevel() {
+        logger.log(Level.OFF, "should not log", null);
+        verifyNoInteractions(delegate);
     }
 
     // Severe level


### PR DESCRIPTION
Motivation
----------

An issue was found where the JUL OFF level was being logged at the error level. This is due to how the log level is determined using integer value checks. The ERROR level is the fallback when it should not be.

Modifications
-------------

A reproducer test was written for the issue and the ERROR threshold was checked to fix the issue. The OFF level is now the fallback which does nothing.

Result
------

The result is the JUL OFF level is now respected.